### PR TITLE
Upgrade from 'qunitjs' to 'qunit' package name

### DIFF
--- a/broccoli/test-tree-builder.js
+++ b/broccoli/test-tree-builder.js
@@ -9,7 +9,7 @@ var esLintBuilder = require('./eslint-tree-builder');
 var path = require('path');
 
 function qunitTree() {
-  var qunitDir = path.dirname(require.resolve('qunitjs'));
+  var qunitDir = path.dirname(require.resolve('qunit'));
 
   return new Funnel(qunitDir, {
     include: [

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "author": "Cory Forsyth <cory.forsyth@gmail.com> (http://coryforsyth.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/201-created/broccoli-test-builder/issues"
+    "url": "https://github.com/bustle/broccoli-test-builder/issues"
   },
-  "homepage": "https://github.com/201-created/broccoli-test-builder",
+  "homepage": "https://github.com/bustle/broccoli-test-builder",
   "dependencies": {
     "broccoli-amd-loader": "^0.2.0",
     "broccoli-babel-transpiler": "^5.6.2",
@@ -27,6 +27,6 @@
     "broccoli-lint-eslint": "^4.0.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-replace": "^0.12.0",
-    "qunitjs": "^2.1.1"
+    "qunit": "^2.11.1"
   }
 }


### PR DESCRIPTION
The qunitjs package name was deprecated with 2.4.1, later
releases are under the 'qunit' name instead.

The directory structure and API remain compatible.

<https://qunitjs.com/intro/#package-name-prior-to-241>